### PR TITLE
Fix #48 by improving Bamboo API interactions

### DIFF
--- a/chroma_feedback/producer/bamboo/core.py
+++ b/chroma_feedback/producer/bamboo/core.py
@@ -46,8 +46,8 @@ def fetch(host : str, slug : str, username : str, password : str) -> List[Dict[s
 
 		if 'results' in data and 'result' in data['results']:
 			for plan in data['results']['result']:
-			    result.append(normalize_data(plan))
+				result.append(normalize_data(plan))
 		else:
-		    result.append(normalize_data(data))
+			result.append(normalize_data(data))
 
 	return result

--- a/chroma_feedback/producer/bamboo/core.py
+++ b/chroma_feedback/producer/bamboo/core.py
@@ -33,7 +33,7 @@ def fetch(host : str, slug : str, username : str, password : str) -> List[Dict[s
 
 	if host and slug and username and password:
 		username_password = username + ':' + password
-		response = requests.get(host + '/rest/api/latest/result/' + slug, headers =
+		response = requests.get(host + '/rest/api/latest/result/' + slug + ("-latest" if "-" in slug else ''), headers =
 		{
 			'Accept': 'application/json',
 			'Authorization': 'Basic ' + base64.b64encode(username_password.encode('utf-8')).decode('ascii')
@@ -45,5 +45,9 @@ def fetch(host : str, slug : str, username : str, password : str) -> List[Dict[s
 		data = helper.parse_json(response)
 
 		if 'results' in data and 'result' in data['results']:
-			result.append(normalize_data(helper.get_first(data['results']['result'])))
+			for plan in data['results']['result']:
+			    result.append(normalize_data(plan))
+		else:
+		    result.append(normalize_data(data))
+
 	return result

--- a/tests/producer/bamboo/test_core.py
+++ b/tests/producer/bamboo/test_core.py
@@ -1,5 +1,46 @@
+import os
+import pytest
 from chroma_feedback.producer.bamboo.core import fetch
 
+# NOTE: Because Bamboo is a commercial server/datacenter product, there
+# are no public instances to run against.  A local trial version can be
+# downloaded using the Atlassian SDK or installed via batch script.
+# To test against a private instance, this procedure should work:
+# - Download and install a trial version of Bamboo.  The setup wizard
+#   will prompt to create an admin user.  Name it 'redaxmedia', then
+#   choose a password.
+# - Create a project named 'redaxmedia' with key 'REDAXMEDIA'.
+# - In that project, create two plans:
+#   - 'chroma-feedback' with key 'CF';
+#   - 'bamboo-producer' with key 'BP'.
+# - Configure each plan to do a trivial task such as an echo statement.
+# - Run both plans so that they have a build status.
+#
+# At this point the tests can be run.  Provide the following envvars:
+# - BAMBOO_HOST : The URL of the Bamboo installation.
+# - BAMBOO_TOKEN: The password of the administrator user.
+
+def test_fetch_project_slug() -> None:
+	if ('BAMBOO_TOKEN' in os.environ) and ('BAMBOO_HOST' in os.environ):
+		result = fetch(os.environ['BAMBOO_HOST'], 'REDAXMEDIA', 'redaxmedia', os.environ['BAMBOO_TOKEN'])
+
+		assert result[0]['producer'] == 'bamboo'
+		assert 'REDAXMEDIA' in result[0]['slug']
+		assert result[0]['active'] is True
+		assert result[0]['status']
+	else:
+		pytest.skip('BAMBOO_USER and BAMBOO_TOKEN must be defined.')
+
+def test_fetch_plan_slug() -> None:
+	if ('BAMBOO_TOKEN' in os.environ) and ('BAMBOO_HOST' in os.environ):
+		result = fetch(os.environ['BAMBOO_HOST'], 'REDAXMEDIA-CF', 'redaxmedia', os.environ['BAMBOO_TOKEN'])
+
+		assert result[0]['producer'] == 'bamboo'
+		assert 'REDAXMEDIA-CF' in result[0]['slug']
+		assert result[0]['active'] is True
+		assert result[0]['status']
+	else:
+		pytest.skip('BAMBOO_USER and BAMBOO_TOKEN must be defined.')
 
 def test_fetch_invalid() -> None:
 	result = fetch(None, None, None, None)


### PR DESCRIPTION
Fixes the anomalous behavior seen in #48 by making two changes:

1. Checks if the slug requested is a plan rather than a project and specifies the plan-specific API call if so.  Dashes are reserved in Bamboo to separate projects and plans in identifiers.
2. Changes the handler to return the entire result set when retrieving a project status.
3. Changes the handler to return the single result element when retrieving a plan status.
