### PR TITLE
feature/add terraform producer v1

### DIFF
--- a/chroma_feedback/color.py
+++ b/chroma_feedback/color.py
@@ -5,6 +5,7 @@ COLOR =\
 	'red': '\033[0;31m',
 	'green': '\033[0;32m',
 	'yellow': '\033[0;33m',
+	'orange': '\033[38:2:255:165:0m',
 	'end': '\033[0m'
 }
 
@@ -21,9 +22,14 @@ def format_yellow(text : str) -> str:
 	return COLOR['yellow'] + text + COLOR['end']
 
 
+def format_orange(text : str) -> str:
+	return COLOR['orange'] + text + COLOR['end']
+
+
 def get_passed() -> Dict[str, Any]:
 	return\
 	{
+		'name': 'green',
 		'rgb':
 		[
 			0,
@@ -46,10 +52,37 @@ def get_passed() -> Dict[str, Any]:
 		'kelvin': 3500
 	}
 
+def get_warning() -> Dict[str, Any]:
+	return\
+	{
+		'name': 'orange',
+		'rgb':
+		[
+			255,
+			127, # This seems very 'yellow' on a Razer Chroma mouse...is 32 better?
+			0
+		],
+		'hue': 5460,
+		'saturation':
+		[
+			100,
+			255,
+			65535
+		],
+		'brightness':
+		[
+			100,
+			255,
+			65535
+		],
+		'kelvin': 3500
+	}
+
 
 def get_process() -> Dict[str, Any]:
 	return\
 	{
+		'name': 'yellow',
 		'rgb':
 		[
 			255,
@@ -76,6 +109,7 @@ def get_process() -> Dict[str, Any]:
 def get_errored() -> Dict[str, Any]:
 	return\
 	{
+		'name': 'white',
 		'rgb':
 		[
 			255,
@@ -102,6 +136,7 @@ def get_errored() -> Dict[str, Any]:
 def get_failed() -> Dict[str, Any]:
 	return\
 	{
+		'name': 'red',
 		'rgb':
 		[
 			255,

--- a/chroma_feedback/consumer/agile_innovative_blinkstick/core.py
+++ b/chroma_feedback/consumer/agile_innovative_blinkstick/core.py
@@ -15,10 +15,10 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str) -> List[Dict[str, Any]]:
+def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	api = get_api()
 	devices = get_devices(api.find_all(), ARGS.agile_innovative_blinkstick_device)
 
 	if not devices:
 		exit(wording.get('device_no') + wording.get('exclamation_mark'))
-	return process_devices(devices, status)
+	return process_devices(devices, status, *args, **kwargs)

--- a/chroma_feedback/consumer/agile_innovative_blinkstick/core.py
+++ b/chroma_feedback/consumer/agile_innovative_blinkstick/core.py
@@ -15,7 +15,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def run(status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	api = get_api()
 	devices = get_devices(api.find_all(), ARGS.agile_innovative_blinkstick_device)
 

--- a/chroma_feedback/consumer/agile_innovative_blinkstick/device.py
+++ b/chroma_feedback/consumer/agile_innovative_blinkstick/device.py
@@ -12,8 +12,10 @@ def get_devices(devices : Any, device_names : List[str]) -> Any:
 	return devices
 
 
-def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
+def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
+
+	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable
 
 	# process devices
 

--- a/chroma_feedback/consumer/agile_innovative_blinkstick/device.py
+++ b/chroma_feedback/consumer/agile_innovative_blinkstick/device.py
@@ -12,7 +12,7 @@ def get_devices(devices : Any, device_names : List[str]) -> Any:
 	return devices
 
 
-def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_devices(devices : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable

--- a/chroma_feedback/consumer/core.py
+++ b/chroma_feedback/consumer/core.py
@@ -4,14 +4,14 @@ import importlib
 from chroma_feedback import helper, wording
 
 
-def process(program : ArgumentParser, status : str) -> List[Dict[str, Any]]:
-	args = helper.get_first(program.parse_known_args())
+def process(program : ArgumentParser, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+	program_args = helper.get_first(program.parse_known_args())
 	result = []
 
-	for consumer_name in args.consumer:
+	for consumer_name in program_args.consumer:
 		consumer = load_consumer(consumer_name)
 		consumer.init(program)
-		result.extend(consumer.run(status))
+		result.extend(consumer.run(status, *args, **kwargs))
 	return result
 
 

--- a/chroma_feedback/consumer/lifx_light/core.py
+++ b/chroma_feedback/consumer/lifx_light/core.py
@@ -17,7 +17,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def run(status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	api = get_api()
 
 	# use groups

--- a/chroma_feedback/consumer/lifx_light/core.py
+++ b/chroma_feedback/consumer/lifx_light/core.py
@@ -17,7 +17,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str) -> List[Dict[str, Any]]:
+def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	api = get_api()
 
 	# use groups
@@ -27,7 +27,7 @@ def run(status : str) -> List[Dict[str, Any]]:
 
 		if not groups:
 			exit(wording.get('group_no') + wording.get('exclamation_mark'))
-		return process_groups(groups, status)
+		return process_groups(groups, status, *args, **kwargs)
 
 	# use lights
 
@@ -35,4 +35,4 @@ def run(status : str) -> List[Dict[str, Any]]:
 
 	if not lights:
 		exit(wording.get('light_no') + wording.get('exclamation_mark'))
-	return process_lights(lights, status)
+	return process_lights(lights, status, *args, **kwargs)

--- a/chroma_feedback/consumer/lifx_light/group.py
+++ b/chroma_feedback/consumer/lifx_light/group.py
@@ -18,8 +18,10 @@ def get_group_name(group : Any) -> Any:
 		return device.get_group_label()
 
 
-def process_groups(groups : Any, status : str) -> List[Dict[str, Any]]:
+def process_groups(groups : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
+
+	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable
 
 	# process groups
 

--- a/chroma_feedback/consumer/lifx_light/group.py
+++ b/chroma_feedback/consumer/lifx_light/group.py
@@ -18,7 +18,7 @@ def get_group_name(group : Any) -> Any:
 		return device.get_group_label()
 
 
-def process_groups(groups : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_groups(groups : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable

--- a/chroma_feedback/consumer/lifx_light/light.py
+++ b/chroma_feedback/consumer/lifx_light/light.py
@@ -13,8 +13,10 @@ def get_lights(lights : Any, light_names : List[str]) -> Any:
 	return lights
 
 
-def process_lights(lights : Any, status : str) -> List[Dict[str, Any]]:
+def process_lights(lights : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
+
+	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable
 
 	# process lights
 

--- a/chroma_feedback/consumer/lifx_light/light.py
+++ b/chroma_feedback/consumer/lifx_light/light.py
@@ -13,7 +13,7 @@ def get_lights(lights : Any, light_names : List[str]) -> Any:
 	return lights
 
 
-def process_lights(lights : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_lights(lights : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable

--- a/chroma_feedback/consumer/philips_hue/core.py
+++ b/chroma_feedback/consumer/philips_hue/core.py
@@ -26,7 +26,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str) -> List[Dict[str, Any]]:
+def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	api = get_api(ARGS.philips_hue_ip)
 
 	# use groups
@@ -36,7 +36,7 @@ def run(status : str) -> List[Dict[str, Any]]:
 
 		if not groups:
 			exit(wording.get('group_no') + wording.get('exclamation_mark'))
-		return process_groups(groups, status)
+		return process_groups(groups, status, *args, **kwargs)
 
 	# use lights
 
@@ -44,7 +44,7 @@ def run(status : str) -> List[Dict[str, Any]]:
 
 	if not lights:
 		exit(wording.get('light_no') + wording.get('exclamation_mark'))
-	return process_lights(lights, status)
+	return process_lights(lights, status, *args, **kwargs)
 
 
 def discover_ips() -> List[str]:

--- a/chroma_feedback/consumer/philips_hue/core.py
+++ b/chroma_feedback/consumer/philips_hue/core.py
@@ -26,7 +26,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def run(status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	api = get_api(ARGS.philips_hue_ip)
 
 	# use groups

--- a/chroma_feedback/consumer/philips_hue/group.py
+++ b/chroma_feedback/consumer/philips_hue/group.py
@@ -14,8 +14,10 @@ def get_groups(groups : Any, group_names : List[str]) -> Any:
 	return groups
 
 
-def process_groups(groups : Any, status : str) -> List[Dict[str, Any]]:
+def process_groups(groups : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
+
+	effect = kwargs.get('effect', 'default')
 
 	# process groups
 
@@ -37,7 +39,7 @@ def process_groups(groups : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'philips_hue',
 				'type': 'group',
 				'name': group_name,
-				'active': static_group(group_name, color.get_process()),
+				'active': pulsate_group(group_name, color.get_warning()) if effect == 'pulse' else static_group(group_name, color.get_process()),
 				'status': status
 			})
 		if status == 'errored':

--- a/chroma_feedback/consumer/philips_hue/group.py
+++ b/chroma_feedback/consumer/philips_hue/group.py
@@ -14,7 +14,7 @@ def get_groups(groups : Any, group_names : List[str]) -> Any:
 	return groups
 
 
-def process_groups(groups : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_groups(groups : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default')

--- a/chroma_feedback/consumer/philips_hue/light.py
+++ b/chroma_feedback/consumer/philips_hue/light.py
@@ -12,7 +12,7 @@ def get_lights(lights : Any, light_names : List[str]) -> Any:
 	return lights
 
 
-def process_lights(lights : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_lights(lights : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default')

--- a/chroma_feedback/consumer/philips_hue/light.py
+++ b/chroma_feedback/consumer/philips_hue/light.py
@@ -12,8 +12,10 @@ def get_lights(lights : Any, light_names : List[str]) -> Any:
 	return lights
 
 
-def process_lights(lights : Any, status : str) -> List[Dict[str, Any]]:
+def process_lights(lights : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
+
+	effect = kwargs.get('effect', 'default')
 
 	# process lights
 
@@ -33,7 +35,7 @@ def process_lights(lights : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'philips_hue',
 				'type': 'light',
 				'name': light.name,
-				'active': static_light(light.name, color.get_process()),
+				'active': pulsate_light(light.name, color.get_warning()) if effect == 'pulse' else static_light(light.name, color.get_process()),
 				'status': status
 			})
 		if status == 'errored':

--- a/chroma_feedback/consumer/razer_chroma/core.py
+++ b/chroma_feedback/consumer/razer_chroma/core.py
@@ -15,10 +15,10 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str) -> List[Dict[str, Any]]:
+def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	api = get_api()
 	devices = get_devices(api.devices, ARGS.razer_chroma_device)
 
 	if not devices:
 		exit(wording.get('device_no') + wording.get('exclamation_mark'))
-	return process_devices(devices, status)
+	return process_devices(devices, status, *args, **kwargs)

--- a/chroma_feedback/consumer/razer_chroma/core.py
+++ b/chroma_feedback/consumer/razer_chroma/core.py
@@ -15,7 +15,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def run(status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	api = get_api()
 	devices = get_devices(api.devices, ARGS.razer_chroma_device)
 

--- a/chroma_feedback/consumer/razer_chroma/device.py
+++ b/chroma_feedback/consumer/razer_chroma/device.py
@@ -11,7 +11,7 @@ def get_devices(devices : Any, device_names : List[str]) -> Any:
 	return devices
 
 
-def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_devices(devices : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default')

--- a/chroma_feedback/consumer/razer_chroma/device.py
+++ b/chroma_feedback/consumer/razer_chroma/device.py
@@ -11,11 +11,12 @@ def get_devices(devices : Any, device_names : List[str]) -> Any:
 	return devices
 
 
-def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
+def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
 
-	# process devices
+	effect = kwargs.get('effect', 'default')
 
+	# process devices
 	for device in devices:
 		if status == 'passed':
 			result.append(
@@ -32,7 +33,7 @@ def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'razer_chroma',
 				'type': 'device',
 				'name': device.name,
-				'active': static_device(device, color.get_process()),
+				'active': pulse_device(device, color.get_warning()) if effect == 'pulse' else static_device(device, color.get_process()),
 				'status': status
 			})
 		if status == 'errored':
@@ -41,7 +42,7 @@ def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'razer_chroma',
 				'type': 'device',
 				'name': device.name,
-				'active': pulsate_device(device, color.get_errored()) or breath_device(device, color.get_errored()),
+				'active': pulse_device(device, color.get_errored()),
 				'status': status
 			})
 		if status == 'failed':
@@ -50,11 +51,13 @@ def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'razer_chroma',
 				'type': 'device',
 				'name': device.name,
-				'active': pulsate_device(device, color.get_failed()) or breath_device(device, color.get_failed()),
+				'active': pulse_device(device, color.get_failed()),
 				'status': status
 			})
 	return result
 
+def pulse_device(device : Any, state : Dict[str, Any]) -> bool:
+	return pulsate_device(device, state) or breath_device(device, state)
 
 def static_device(device : Any, state : Dict[str, Any]) -> bool:
 	if device.has('brightness'):

--- a/chroma_feedback/consumer/thingm_blink/core.py
+++ b/chroma_feedback/consumer/thingm_blink/core.py
@@ -15,7 +15,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def run(status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	api = get_api()
 	devices = get_devices(api.list(), ARGS.thingm_blink_device)
 

--- a/chroma_feedback/consumer/thingm_blink/core.py
+++ b/chroma_feedback/consumer/thingm_blink/core.py
@@ -15,10 +15,10 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str) -> List[Dict[str, Any]]:
+def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	api = get_api()
 	devices = get_devices(api.list(), ARGS.thingm_blink_device)
 
 	if not devices:
 		exit(wording.get('device_no') + wording.get('exclamation_mark'))
-	return process_devices(devices, status)
+	return process_devices(devices, status, *args, **kwargs)

--- a/chroma_feedback/consumer/thingm_blink/device.py
+++ b/chroma_feedback/consumer/thingm_blink/device.py
@@ -12,7 +12,7 @@ def get_devices(devices : Any, device_names : List[str]) -> Any:
 	return devices
 
 
-def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_devices(devices : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default')

--- a/chroma_feedback/consumer/thingm_blink/device.py
+++ b/chroma_feedback/consumer/thingm_blink/device.py
@@ -35,7 +35,7 @@ def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[s
 				'consumer': 'thingm_blink',
 				'type': 'device',
 				'name': device,
-				'active': pulsate_device(color.get_warning()) if effect == 'pulse' else static_device(color.get_process()),
+				'active': pulse_device(color.get_warning()) if effect == 'pulse' else static_device(color.get_process()),
 				'status': status
 			})
 		if status == 'errored':
@@ -44,7 +44,7 @@ def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[s
 				'consumer': 'thingm_blink',
 				'type': 'device',
 				'name': device,
-				'active': pulsate_device(color.get_errored()),
+				'active': pulse_device(color.get_errored()),
 				'status': status
 			})
 		if status == 'failed':
@@ -53,7 +53,7 @@ def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[s
 				'consumer': 'thingm_blink',
 				'type': 'device',
 				'name': device,
-				'active': pulsate_device(color.get_failed()),
+				'active': pulse_device(color.get_failed()),
 				'status': status
 			})
 	return result
@@ -64,7 +64,7 @@ def static_device(state : Dict[str, Any]) -> bool:
 
 	return api is not None and api.fade_to_rgb(0, state['rgb'][0], state['rgb'][1], state['rgb'][2]) is None
 
-def pulsate_device(state : Dict[str, Any]) -> bool:
+def pulse_device(state : Dict[str, Any]) -> bool:
 	api = get_api()
 
 	if api is not None:

--- a/chroma_feedback/consumer/thingm_blink/device.py
+++ b/chroma_feedback/consumer/thingm_blink/device.py
@@ -12,8 +12,10 @@ def get_devices(devices : Any, device_names : List[str]) -> Any:
 	return devices
 
 
-def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
+def process_devices(devices : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
+
+	effect = kwargs.get('effect', 'default')
 
 	# process devices
 
@@ -33,7 +35,7 @@ def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'thingm_blink',
 				'type': 'device',
 				'name': device,
-				'active': static_device(color.get_process()),
+				'active': pulsate_device(color.get_warning()) if effect == 'pulse' else static_device(color.get_process()),
 				'status': status
 			})
 		if status == 'errored':
@@ -42,7 +44,7 @@ def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'thingm_blink',
 				'type': 'device',
 				'name': device,
-				'active': static_device(color.get_errored()),
+				'active': pulsate_device(color.get_errored()),
 				'status': status
 			})
 		if status == 'failed':
@@ -51,7 +53,7 @@ def process_devices(devices : Any, status : str) -> List[Dict[str, Any]]:
 				'consumer': 'thingm_blink',
 				'type': 'device',
 				'name': device,
-				'active': static_device(color.get_failed()),
+				'active': pulsate_device(color.get_failed()),
 				'status': status
 			})
 	return result
@@ -61,3 +63,13 @@ def static_device(state : Dict[str, Any]) -> bool:
 	api = get_api()
 
 	return api is not None and api.fade_to_rgb(0, state['rgb'][0], state['rgb'][1], state['rgb'][2]) is None
+
+def pulsate_device(state : Dict[str, Any]) -> bool:
+	api = get_api()
+
+	if api is not None:
+		api.write_pattern_line(2000, 'black', 0)
+		api.write_pattern_line(2000, state['name'],  1)
+		return api.play(0,1,0) is None
+
+	return False

--- a/chroma_feedback/consumer/xiaomi_yeelight/core.py
+++ b/chroma_feedback/consumer/xiaomi_yeelight/core.py
@@ -22,7 +22,7 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def run(status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	lights = get_lights(ARGS.xiaomi_yeelight_ip)
 
 	if not lights:

--- a/chroma_feedback/consumer/xiaomi_yeelight/core.py
+++ b/chroma_feedback/consumer/xiaomi_yeelight/core.py
@@ -22,12 +22,12 @@ def init(program : ArgumentParser) -> None:
 	ARGS = helper.get_first(program.parse_known_args())
 
 
-def run(status : str) -> List[Dict[str, Any]]:
+def run(status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	lights = get_lights(ARGS.xiaomi_yeelight_ip)
 
 	if not lights:
 		exit(wording.get('light_no') + wording.get('exclamation_mark'))
-	return process_lights(lights, status)
+	return process_lights(lights, status, *args, **kwargs)
 
 
 def discover_ips() -> List[str]:

--- a/chroma_feedback/consumer/xiaomi_yeelight/light.py
+++ b/chroma_feedback/consumer/xiaomi_yeelight/light.py
@@ -11,8 +11,10 @@ def get_lights(ips : List[str]) -> List[Dict[str, Any]]:
 	return lights
 
 
-def process_lights(lights : Any, status : str) -> List[Dict[str, Any]]:
+def process_lights(lights : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
 	result = []
+
+	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable
 
 	# process lights
 

--- a/chroma_feedback/consumer/xiaomi_yeelight/light.py
+++ b/chroma_feedback/consumer/xiaomi_yeelight/light.py
@@ -11,7 +11,7 @@ def get_lights(ips : List[str]) -> List[Dict[str, Any]]:
 	return lights
 
 
-def process_lights(lights : Any, status : str, *args, **kwargs) -> List[Dict[str, Any]]:
+def process_lights(lights : Any, status : str, *args : str, **kwargs : str) -> List[Dict[str, Any]]:
 	result = []
 
 	effect = kwargs.get('effect', 'default') # pylint: disable=unused-variable

--- a/chroma_feedback/core.py
+++ b/chroma_feedback/core.py
@@ -27,7 +27,6 @@ def run(program : ArgumentParser) -> None:
 		exit(wording.get('result_no') + wording.get('exclamation_mark'))
 
 	# report producer
-
 	producer_report = reporter.create_producer_report(producer_result)
 	if producer_report:
 		reporter.print_report(producer_report)
@@ -41,8 +40,8 @@ def run(program : ArgumentParser) -> None:
 		# process consumer
 
 		status = helper.get_producer_status(producer_result)
-		consumer_result = consumer.process(program, status)
-
+		effect = helper.get_producer_effect(producer_result)
+		consumer_result = consumer.process(program, status, effect = effect)
 		# report consumer
 
 		consumer_report = reporter.create_consumer_report(consumer_result)

--- a/chroma_feedback/helper.py
+++ b/chroma_feedback/helper.py
@@ -20,6 +20,11 @@ def get_producer_status(producer_result : List[Dict[str, Any]]) -> str:
 				status = 'failed'
 	return status
 
+def get_producer_effect(producer_result : List[Dict[str, Any]]) -> str:
+	for producer in producer_result:
+		if producer['active'] is True:
+			return producer.get('effect', 'default')
+	return 'default'
 
 def parse_json(response : Response) -> Any:
 	try:

--- a/chroma_feedback/metadata.py
+++ b/chroma_feedback/metadata.py
@@ -4,7 +4,7 @@ METADATA =\
 	'description': 'Turn your RGB powered hardware into an build indicator for continuous integration',
 	'version': '7.2.0',
 	'license': 'GPL-3.0',
-	'keywords': 'appveyor bamboo circle codeship github gitlab jenkins teamcity travis',
+	'keywords': 'appveyor bamboo circle codeship github gitlab jenkins teamcity terraform travis',
 	'author': 'Henry Ruhs',
 	'author_email': 'info@redaxmedia.com',
 	'url': 'https://github.com/redaxmedia/chroma-feedback'

--- a/chroma_feedback/producer/__init__.py
+++ b/chroma_feedback/producer/__init__.py
@@ -10,6 +10,7 @@ __all__ =\
 	'gitlab',
 	'jenkins',
 	'teamcity',
+	'terraform',
 	'travis',
 	'wercker'
 ]

--- a/chroma_feedback/producer/terraform/__init__.py
+++ b/chroma_feedback/producer/terraform/__init__.py
@@ -1,0 +1,1 @@
+from .core import init, run

--- a/chroma_feedback/producer/terraform/core.py
+++ b/chroma_feedback/producer/terraform/core.py
@@ -1,0 +1,83 @@
+from typing import Any, Dict, List
+from argparse import ArgumentParser
+import os
+import requests
+from chroma_feedback import helper
+from .normalize import normalize_data
+
+ARGS = None
+
+
+def init(program : ArgumentParser) -> None:
+	global ARGS
+
+	if not ARGS:
+		program.add_argument('--terraform-host', default = 'https://app.terraform.io')
+		program.add_argument('--terraform-slug', action = 'append', required = True)
+		program.add_argument('--terraform-token', default = os.environ['TFE_TOKEN'])
+	ARGS = helper.get_first(program.parse_known_args())
+
+
+def run() -> List[Dict[str, Any]]:
+	result = []
+
+	for slug in ARGS.terraform_slug:
+		result.extend(fetch(ARGS.terraform_host, slug, ARGS.terraform_token))
+	return result
+
+
+def fetch(host : str, slug : str, token : str) -> List[Dict[str, Any]]:
+	result = []
+	response = None
+
+	if host and slug and token:
+		api = parse_slug(slug)
+		headers = {
+			'Content-Type': 'application/vnd.api+json',
+			'Authorization': "Bearer " + token
+		}
+		params = {
+			'include': 'current_run'
+		}
+		response = requests.get(host + '/api/v2' + api, params = params, headers = headers)
+
+	# process response
+	if response and response.status_code == 200:
+		json = helper.parse_json(response)
+		if 'data' in json and 'included' in json:
+			if isinstance(json['data'], dict):
+				# Single result, either ws ID or name
+				data = {
+					'id': slug,
+					'status': json['included'][0]['attributes']['status']
+				}
+				result.append(normalize_data(data))
+			if isinstance(json['data'], list):
+				wsnames = [ sub['attributes']['name'] for sub in json['data'] ]
+				wsstatuses = [ sub['attributes']['status'] for sub in json['included'] ]
+				for workspace, status in zip(wsnames, wsstatuses):
+					data = {
+						'id': slug + "/" + workspace,
+						'status': status
+					}
+					result.append(normalize_data(data))
+		return result
+
+
+def parse_slug(slug : str):
+	if slug:
+		tokens = slug.split('/')
+		if len(tokens) == 1:
+			if tokens[0].startswith('ws-'):  # It's a workspace ID
+				organization = ""
+				workspace = "/workspaces/" + tokens[0]
+			else: # It's a whole organization
+				organization = "/organizations/" + tokens[0]
+				workspace = "/workspaces"
+		else:
+			organization = "/organizations/" + tokens[0]
+			workspace = "/workspaces/" + tokens[1]
+			# If there are more than two tokens it's a mistake.
+
+		return organization + workspace
+	return None

--- a/chroma_feedback/producer/terraform/core.py
+++ b/chroma_feedback/producer/terraform/core.py
@@ -61,10 +61,11 @@ def fetch(host : str, slug : str, token : str) -> List[Dict[str, Any]]:
 						'status': status
 					}
 					result.append(normalize_data(data))
-		return result
+
+	return result
 
 
-def parse_slug(slug : str):
+def parse_slug(slug : str) -> str:
 	if slug:
 		tokens = slug.split('/')
 		if len(tokens) == 1:

--- a/chroma_feedback/producer/terraform/normalize.py
+++ b/chroma_feedback/producer/terraform/normalize.py
@@ -1,0 +1,47 @@
+from typing import Any, Dict
+
+
+def normalize_data(project : Dict[str, Any]) -> Dict[str, Any]:
+	return\
+	{
+		'producer': 'terraform',
+		'slug': project['id'],
+		'active': True,
+		'status': normalize_status(project['status'].lower()),
+		'effect': normalize_effect(project['status'].lower())
+	}
+
+
+def normalize_status(status : str) -> str:
+	statuses = {
+		# Statuses with a '*' require manual intervention in TFE.
+		'pending': 'process',				# Not running yet
+		'plan-queued': 'process',			# Waiting to plan
+		'planning': 'process',				# Checking infrastructure
+		'canceled': 'failed',				# Run was cancelled
+		'discarded': 'errored',				# Plan finished but was not applied
+		'planned': 'process',				# Plan succeeded, needs approval *
+		'planned-and-finished': 'passed',	# No changes, infrastructure OK
+		'none': 'passed',					# Never run
+		'cost-estimating': 'process',		# If you have it, TF estimates cost
+		'cost-estimated': 'process', 		# of infrastructure.  Automatic...
+		'policy-checking': 'process',		# Sentinel policies are run
+		'policy-soft-failed': 'process', 	# A soft failure can be approved *
+		'policy-override': 'process', 		# Applying over soft-fail policy
+		'policy-checked': 'process', 		# Automatic, proceed to pre-apply
+		'confirmed': 'process',				# Plan was confirmed, apply is next
+		'apply-queued': 'process',			# Waiting to apply
+		'applying': 'process',				# Apply in process
+		'errored': 'failed',				# Apply had an error
+		'applied': 'passed'					# Apply successful
+	}
+
+	return statuses.get(status, 'passed')
+
+def normalize_effect(status : str) -> str:
+	effects = {
+		'planned': 'pulse',
+		'policy-soft-failed': 'pulse'
+	}
+
+	return effects.get(status, 'default')

--- a/tests/producer/terraform/test_core.py
+++ b/tests/producer/terraform/test_core.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+from chroma_feedback.producer.gitlab.core import fetch
+
+
+def test_fetch_slug() -> None:
+	if 'TFE_TOKEN' in os.environ:
+		result = fetch('https://app.terraform.io', 'redaxmedia/chroma-feedback', os.environ['TFE_TOKEN'])
+
+		assert result[0]['producer'] == 'terraform'
+		assert result[0]['slug']
+		assert result[0]['active'] is True
+		assert result[0]['status']
+		assert result[0]['effect']
+	else:
+		pytest.skip('TFE_TOKEN is not defined')
+
+
+def test_fetch_invalid() -> None:
+	result = fetch(None, None, None)
+
+	assert result == []

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -4,6 +4,9 @@ from chroma_feedback import color
 def test_format_red() -> None:
 	assert color.format_red('__test__') == '\033[0;31m__test__\033[0m'
 
+def test_format_orange() -> None:
+	assert color.format_orange('__test__') == '\033[38:2:255:165:0m__test__\033[0m'
+
 
 def test_format_green() -> None:
 	assert color.format_green('__test__') == '\033[0;32m__test__\033[0m'
@@ -16,6 +19,7 @@ def test_format_yellow() -> None:
 def test_get_passed() -> None:
 	state = color.get_passed()
 
+	assert 'name' in state
 	assert 'rgb' in state
 	assert 'hue' in state
 	assert 'saturation' in state
@@ -26,6 +30,18 @@ def test_get_passed() -> None:
 def test_get_process() -> None:
 	state = color.get_process()
 
+	assert 'name' in state
+	assert 'rgb' in state
+	assert 'hue' in state
+	assert 'saturation' in state
+	assert 'brightness' in state
+	assert 'kelvin' in state
+
+
+def test_get_warning() -> None:
+	state = color.get_warning()
+
+	assert 'name' in state
 	assert 'rgb' in state
 	assert 'hue' in state
 	assert 'saturation' in state
@@ -36,6 +52,7 @@ def test_get_process() -> None:
 def test_get_errored() -> None:
 	state = color.get_errored()
 
+	assert 'name' in state
 	assert 'rgb' in state
 	assert 'hue' in state
 	assert 'saturation' in state
@@ -46,6 +63,7 @@ def test_get_errored() -> None:
 def test_get_failed() -> None:
 	state = color.get_failed()
 
+	assert 'name' in state
 	assert 'rgb' in state
 	assert 'hue' in state
 	assert 'saturation' in state


### PR DESCRIPTION
Add Terraform Cloud producer support to #57 

Unfortunately I broke one of my own rules in implementing this as this contains some feature creep.
Terraform has many statuses, some of which require user intervention, and I need that support in order to make the visualization useful.  This branch:
- Adds Terraform Cloud support for calls for workspace name, ID, and whole organization

But, it also:
- Adds support for *all* producers/consumers to pass/consume an effect type as kwargs
- Adds an orange color for 'warning' status
- Adds ability for Terraform producer to pass an optional effect for user-intervention status
- Changes Razer Chroma and blink1 to parse passed effects