### PR TITLE
fix: add missing 'failing' status for CircleCI

### DIFF
--- a/chroma_feedback/producer/circle/normalize.py
+++ b/chroma_feedback/producer/circle/normalize.py
@@ -19,6 +19,6 @@ def normalize_status(status : str) -> str:
 		return 'started'
 	if status in ['canceled', 'no_tests']:
 		return 'errored'
-	if status == 'failed':
+	if status in ['failed', 'failing']:
 		return 'failed'
 	return 'passed'


### PR DESCRIPTION
When a step failed in CircleCI and that it knows that the build is going to fail, it has the "failing" status.

As unknown statuses are considered as "passed", it can be confusing and make think that everything is fine, but it actually is not !